### PR TITLE
Fixed warn_unused_result warning in Ubuntu build

### DIFF
--- a/core/linux/FdPoller.h
+++ b/core/linux/FdPoller.h
@@ -40,7 +40,7 @@ class FdPoller {
             return pollingFds[0].revents != 0;
         }
         void Cancel() {
-            write(pipeFds[1], " ", 1);
+            (void)! write(pipeFds[1], " ", 1);
         }
     private:
         int pipeFds[2];

--- a/unit_tests/LinuxPollTests.cpp
+++ b/unit_tests/LinuxPollTests.cpp
@@ -74,7 +74,7 @@ TEST(Poll, PollSucceeds) {
     };
     auto start = std::chrono::steady_clock::now();
     auto waiter = std::async(std::launch::async, Poll, 500);
-    write(pipeFds[1], " ", 1);
+    (void)! write(pipeFds[1], " ", 1);
     RDMA_ASSERT_NO_THROW( EXPECT_TRUE(waiter.get()) );
     ASSERT_LT(std::chrono::steady_clock::now()-start, std::chrono::milliseconds(100));
     close(pipeFds[0]);


### PR DESCRIPTION
Write() is complaining when the returned value isn't checked or used.
Explicitly marked the function as void and not to be optimized by compiler (otherwise the same warning will popup again)