### PR TITLE
Added Windows 2022 and Ubuntu 22.04 configuration

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: ubuntu-20.04, platform_version: 20.04, boost_version: 1.73.0 }
           - { os: ubuntu-22.04, platform_version: 22.04, boost_version: 1.79.0 }
           - { os: windows-2019, platform_version: 2019,  boost_version: 1.73.0 }
-          - { os: windows-2022, platform_version: 2019,  boost_version: 1.79.0, toolset: msvc }
+          - { os: windows-2022, platform_version: 2022,  boost_version: 1.79.0, toolset: msvc }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,8 +19,10 @@ jobs:
     strategy:
       matrix:
         cfg: 
-          - { os: ubuntu-20.04, platform_version: 20.04 }
-          - { os: windows-2019, platform_version: 2019 }
+          - { os: ubuntu-20.04, platform_version: 20.04, boost_version: 1.73.0 }
+          - { os: ubuntu-22.04, platform_version: 22.04, boost_version: 1.79.0 }
+          - { os: windows-2019, platform_version: 2019,  boost_version: 1.73.0 }
+          - { os: windows-2022, platform_version: 2019,  boost_version: 1.79.0, toolset: msvc }
 
     steps:
       - uses: actions/checkout@v3
@@ -30,8 +32,9 @@ jobs:
         id:   install-boost
         with:
           # Please update CONTIRBUTING.md if the version is changed
-          boost_version: 1.73.0
-          platform_version: ${{ matrix.cfg.platform_version }} 
+          boost_version: ${{ matrix.cfg.boost_version }}
+          platform_version: ${{ matrix.cfg.platform_version }}
+          toolset: ${{ matrix.cfg.toolset }}
           
       - name: Setup NuGet (Windows)
         if:   contains(matrix.cfg.os, 'windows')

--- a/core/linux/RdmaEnumeration.cpp
+++ b/core/linux/RdmaEnumeration.cpp
@@ -7,7 +7,7 @@
 #include <net/if.h>
 #include <boost/filesystem.hpp>
 #include <boost/range.hpp>
-#include <sstream>
+#include <fstream>
 
 struct InterfaceInfo {
     uint32_t ifIndex = -1;


### PR DESCRIPTION
boost/1.7.9 is the minimum supported version for both Windows 2022 and Ubuntu 22.04 For Windows, msvc toolset is chosen, otherwise install-boost will randomly choose between msvc or mingw. At the moment, cmake configuration doesn't work with boost when mingw is selected.

Signed-off-by: Kevin Lim <khai-wern.lim@ni.com>