### PR TITLE
Include cstring in RdmaAddress.h

### DIFF
--- a/core/common/RdmaAddress.h
+++ b/core/common/RdmaAddress.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <memory>
 #include <functional>
+#include <cstring>
 #include <string>
 #include <iostream>
 #include <regex>


### PR DESCRIPTION
Building on Fedora 38 I get a bunch of errors like:
easyrdma-src/core/common/RdmaAddress.h:76:9: error: ‘memcpy’ was not declared in this scope 
easyrdma-src/core/common/RdmaAddress.h:116:31: error: ‘strlen’ was not declared in this scope

 etc...